### PR TITLE
move middleware inside server

### DIFF
--- a/open-next.config.ts
+++ b/open-next.config.ts
@@ -9,20 +9,6 @@ const config = {
       queue: "sqs-lite",
     },
   },
-  functions: {
-    // edge: {
-    //   runtime: "edge",
-    //   routes: [
-    //     "app/(admin)/(auth)/signin/page",
-    //     "app/(admin)/(auth)/signup/page",
-    //   ],
-    //   patterns: ["app/(admin)/(auth)/*"],
-    //   override: {},
-    // },
-  },
-  middleware: {
-    external: true,
-  },
 } satisfies OpenNextConfig;
 
 export default config;


### PR DESCRIPTION
for now sst doesn't support link of resources in lambda@edge, external middleware uses lambda@edge for that